### PR TITLE
Update dependencies

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,9 +1,9 @@
 <Project>
     <PropertyGroup>
-        <CmsCoreVersion>12.5.0</CmsCoreVersion>
-        <CmsUIVersion>12.6.0</CmsUIVersion>
-        <TelemetryVersion>2.2.0</TelemetryVersion>
-        <TinyMceVersion>3.2.0</TinyMceVersion>
+        <CmsCoreVersion>12.9.0</CmsCoreVersion>
+        <CmsUIVersion>12.12.1-feature-CMS-23555-028316</CmsUIVersion>
+        <TelemetryVersion>2.2.2-feature-CMS-23555-020191</TelemetryVersion>
+        <TinyMceVersion>3.3.1</TinyMceVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/EPiServer.Labs.BlockEnhancements.Test/dojoConfig.js
+++ b/src/EPiServer.Labs.BlockEnhancements.Test/dojoConfig.js
@@ -25,7 +25,7 @@ var dojoConfig = {
         { name: "put-selector", location: "/base/out/dtk/put-selector" },
         { name: "epi", location: "/base/out/dtk/epi" },
         { name: "epi-cms", location: "/base/out/dtk/epi-cms" },
-        { name: "episerver-telemetry-ui", location: "/base/out/dtk/episerver-telemetry-ui/2.2.0/ClientResources" },
+        { name: "episerver-telemetry-ui", location: "/base/out/dtk/episerver-telemetry-ui/2.2.2-feature-CMS-23555-020191/ClientResources" },
         { name: "episerver-labs-block-enhancements", location: "/base/src/EPiServer.Labs.BlockEnhancements/ClientResources" },
         { name: "mocks", location: "/base/src/EPiServer.Labs.BlockEnhancements.Test/Mocks" },
         { name: "tdd", location: "/base/src/EPiServer.Labs.BlockEnhancements.Test/tdd"}

--- a/src/EPiServer.Labs.BlockEnhancements/InlineBlocksEditing/CustomProjectService.cs
+++ b/src/EPiServer.Labs.BlockEnhancements/InlineBlocksEditing/CustomProjectService.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using EPiServer.Cms.Shell.Service.Internal;
 using EPiServer.Cms.Shell.UI.Rest;
-using EPiServer.Cms.Shell.UI.Rest.Approvals;
+using EPiServer.Cms.Shell.UI.Rest.Approvals.Internal;
 using EPiServer.Cms.Shell.UI.Rest.Projects;
 using EPiServer.Cms.Shell.UI.Rest.Projects.Internal;
 using EPiServer.Core;

--- a/src/EPiServer.Labs.BlockEnhancements/ServiceCollectionExtensions.cs
+++ b/src/EPiServer.Labs.BlockEnhancements/ServiceCollectionExtensions.cs
@@ -20,6 +20,16 @@ namespace EPiServer.Labs.BlockEnhancements
                     }
                 });
 
+            services.Configure<ProtectedModuleOptions>(
+                pm =>
+                {
+                    if (!pm.Items.Any(i =>
+                            i.Name.Equals("episerver-telemetry-ui", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        pm.Items.Add(new ModuleDetails { Name = "episerver-telemetry-ui" });
+                    }
+                });
+
             if (blockEnhancementsOptions != null)
             {
                 services.Configure(blockEnhancementsOptions);


### PR DESCRIPTION
Most of Telemetry related code has been moved
directly to CMS UI.
BlockEnhancements labs still use AppInsights which means it has to manually register the protected
module until we migrate it to Gainsight.
Then we will be able to remove the dependency.