### PR TITLE
Use policy in favor of direct users/roles

### DIFF
--- a/src/Alloy.Sample/Alloy.Sample.csproj
+++ b/src/Alloy.Sample/Alloy.Sample.csproj
@@ -29,4 +29,7 @@
   <ItemGroup>
     <ProjectReference Include="..\EPiServer.Labs.BlockEnhancements\EPiServer.Labs.BlockEnhancements.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Remove="module.config" />
+  </ItemGroup>
 </Project>

--- a/src/Alloy.Sample/Business/Plugins/NewsGeneratorPlugin.cs
+++ b/src/Alloy.Sample/Business/Plugins/NewsGeneratorPlugin.cs
@@ -9,6 +9,7 @@ using Alloy.Sample.Models.Blocks;
 using Alloy.Sample.Models.Media;
 using Alloy.Sample.Models.Pages;
 using EPiServer;
+using EPiServer.Authorization;
 using EPiServer.Cms.Shell;
 using EPiServer.Core;
 using EPiServer.DataAccess;
@@ -44,7 +45,7 @@ namespace Alloy.Sample.Business.Plugins
     }
 
 
-    [Authorize(Roles = "CmsAdmin,WebAdmins,Administrators")]
+    [Authorize(Policy = CmsPolicyNames.CmsAdmin)]
     public class NewsGeneratorPluginController : Controller
     {
         public IActionResult Index()

--- a/src/EPiServer.Labs.BlockEnhancements/EPiServer.Labs.BlockEnhancements.csproj
+++ b/src/EPiServer.Labs.BlockEnhancements/EPiServer.Labs.BlockEnhancements.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <Import Project="..\..\build\nuspec.props" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>NU5125</NoWarn>
     <NuspecFile>EPiServer.Labs.BlockEnhancements.nuspec</NuspecFile>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
@@ -11,8 +11,5 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EPiServer.CMS.UI.Core" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Remove="module.config" />
   </ItemGroup>
 </Project>

--- a/src/EPiServer.Labs.BlockEnhancements/SharedBlocksConverter/SharedBlocksConverterPluginController.cs
+++ b/src/EPiServer.Labs.BlockEnhancements/SharedBlocksConverter/SharedBlocksConverterPluginController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using EPiServer.Authorization;
 using EPiServer.Core;
 using EPiServer.Shell.Web.Mvc;
 using Microsoft.AspNetCore.Authorization;
@@ -6,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace EPiServer.Labs.BlockEnhancements.SharedBlocksConverter;
 
-[Authorize(Roles = "CmsAdmin,WebAdmins,Administrators")]
+[Authorize(Policy = CmsPolicyNames.CmsAdmin)]
 public class SharedBlocksConverterPluginController : Controller
 {
     private readonly ConvertInlineBlocks _convertInlineBlocks;

--- a/src/EPiServer.Labs.BlockEnhancements/module.config
+++ b/src/EPiServer.Labs.BlockEnhancements/module.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<module productName="episerver-labs-block-enhancements" viewEngine="Razor">
+<module productName="episerver-labs-block-enhancements" viewEngine="Razor" authorizationPolicy="episerver:cmsadmin">
   <assemblies>
     <add assembly="EPiServer.Labs.BlockEnhancements" />
   </assemblies>


### PR DESCRIPTION
When using the Authorize plugin we should rely on policies in favor of old way with roles/users.

Fixes: [CMS-29618](https://jira.sso.episerver.net/browse/CMS-29618)